### PR TITLE
Fix salt bug; use binaries instead of strings

### DIFF
--- a/lib/bcrypt.ex
+++ b/lib/bcrypt.ex
@@ -48,9 +48,7 @@ defmodule Bcrypt do
   """
   def gen_salt(log_rounds \\ 12, legacy \\ false) do
     :crypto.strong_rand_bytes(16)
-    |> :binary.bin_to_list()
     |> Base.gensalt_nif(log_rounds, (legacy and 97) || 98)
-    |> :binary.list_to_bin()
   end
 
   @doc """

--- a/lib/bcrypt/base.ex
+++ b/lib/bcrypt/base.ex
@@ -60,7 +60,6 @@ defmodule Bcrypt.Base do
 
   defp hash(password, salt, prefix) when prefix in ["2a", "2b"] do
     hash_nif(:binary.bin_to_list(password), :binary.bin_to_list(salt))
-    |> :binary.list_to_bin()
   end
 
   defp hash(_, _, prefix) do


### PR DESCRIPTION
This PR contains two related changes. The first is to fix a bug in `bcrypt_gensalt_nif/3`. Because it was using `enif_make_string/3` to generate its return value, the last byte would always be set to 0, regardless of what it should actually have been. This means that the generated salts had one byte less entropy than they should have. Not the end of the world, but not ideal either.

I also changed places where binaries were being passed between the VM and the NIF to use binary terms rather than strings/lists. In the case of `bcrypt_gensalt_nif/3`, for example, changing the random bytes to a list then reading them as a null-terminated string using `enif_get_string/2` could have resulted in the bytes being truncated at the first 0 byte. In reality that didn't happen because of the internal implementation details of `enif_get_string/2` which copies the entire target length, but it would have been well within its rights to only copy to the first null. Semantics aside, though, it uses extra memory and processing to convert from a binary to a list and back when there's no need to do so.

Where the underlying C code expected a null-terminated string, I left the terms being passed as lists (mostly to limit the scope of this PR) but really for optimisation purposes those should probably be changed as well.