### PR TITLE
Add a note about compiling in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ In order to use `bcrypt_elixir` in Docker, you will probably need to manually co
 
 ```
 RUN apk add --no-cache make gcc libc-dev
-
-RUN cd deps/bcrypt_elixir && make clean && make
 ```
+
+Remember to add your local `_build` and `deps` folders to `.dockerignore`, because otherwise, you'll see errors coming up.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ For a lower-level api, see the documentation for Bcrypt.Base.
 For further information about password hashing and using Bcrypt with Comeonin,
 see the Comeonin [wiki](https://github.com/riverrun/comeonin/wiki).
 
+## Docker
+
+In order to use `bcrypt_elixir` in Docker, you will probably need to manually compile it in your Dockerfile. In order to do it on the Alpine image, you're going to need `make`, `gcc` and `libc-dev`. Add the following lines to your Dockerfile, right after `RUN mix deps.get`
+
+```
+RUN apk add --no-cache make gcc libc-dev
+
+RUN cd deps/bcrypt_elixir && make clean && make
+```
+
 ## Deployment
 
 See the Comeonin [deployment guide](https://github.com/riverrun/comeonin/wiki/Deployment).


### PR DESCRIPTION
I've chosen to add this paragraph, because I found this info quite hard to find anywhere. I've also added it to Comeonin docs so that it'll be easier to find, but I think that it might be useful to have it both in bcrypt readme and Comeonin docs, because some people might want to use them separately.