### PR TITLE
Fixed compilation issue when erlang path includes a space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CFLAGS = -g -O3 -Wall -Wno-format-truncation
 
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
-CFLAGS += -I$(ERLANG_PATH)
+CFLAGS += -I"$(ERLANG_PATH)"
 CFLAGS += -Ic_src
 
 LIB_NAME = priv/bcrypt_nif.so


### PR DESCRIPTION
The commit message has more details

The short is: erlang installed in a path that contains spaces causes the include path to split on the command line, I've solved this by just quoting the path