### PR TITLE
Update Makefile to work better on Nerves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ NIF_SRC=\
 	c_src/bcrypt_nif.c\
 	c_src/blowfish.c
 
+calling_from_make:
+	mix compile
+
 all: $(PRIV_DIR) $(LIB_NAME)
 
 $(LIB_NAME): $(NIF_SRC)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CFLAGS = -g -O3 -Wall -Wno-format-truncation
+CFLAGS ?= -g -O3
+CFLAGS += -Wall -Wno-format-truncation
 
 CFLAGS += -I"$(ERTS_INCLUDE_DIR)"
 CFLAGS += -Ic_src

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 CFLAGS = -g -O3 -Wall -Wno-format-truncation
 
-ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
-CFLAGS += -I"$(ERLANG_PATH)"
+CFLAGS += -I"$(ERTS_INCLUDE_DIR)"
 CFLAGS += -Ic_src
 
-LIB_NAME = priv/bcrypt_nif.so
+PRIV_DIR = $(MIX_APP_PATH)/priv
+LIB_NAME = $(PRIV_DIR)/bcrypt_nif.so
 ifneq ($(CROSSCOMPILE),)
     # crosscompiling
     CFLAGS += -fPIC
@@ -23,11 +23,13 @@ NIF_SRC=\
 	c_src/bcrypt_nif.c\
 	c_src/blowfish.c
 
-all: $(LIB_NAME)
+all: $(PRIV_DIR) $(LIB_NAME)
 
 $(LIB_NAME): $(NIF_SRC)
-	mkdir -p priv
 	$(CC) $(CFLAGS) -shared $(LDFLAGS) $^ -o $@
+
+$(PRIV_DIR):
+	mkdir -p $@
 
 clean:
 	rm -f $(LIB_NAME)

--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,7 @@ defmodule BcryptElixir.Mixfile do
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       compilers: [:elixir_make] ++ Mix.compilers(),
+      make_clean: ["clean"],
       description: @description,
       package: package(),
       source_url: "https://github.com/riverrun/bcrypt_elixir",

--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,7 @@ defmodule BcryptElixir.Mixfile do
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       compilers: [:elixir_make] ++ Mix.compilers(),
+      make_targets: ["all"],
       make_clean: ["clean"],
       description: @description,
       package: package(),


### PR DESCRIPTION
This update has several changes and can easily be broken up into multiple PRs if one or more are undesirable.

The main improvement is to output the NIF shared library under `_build`. This helps #29 since what was happening was that an Intel version of the shared library was getting left under the `deps` directory and not being rebuilt when in M1 mode. Intuitively, one might think of removing the `_build` directory when doing a rebuild after changing between M1 and Intel mode. When build products are stored in the source directory, you also have to clean up the `deps` directory too. This really helps Nerves users, though, since it's common to build for different target CPU architectures and `mix` will create a separate build directory for each one. It only works, though, if you output the NIF under the `_build` directory.

While making the change, I made a few other improvements to help Nerves users. The commit messages have more information. 

I tested these on Linux and Nerves. I have no reason to believe that OSX builds are broken since the call to `cc` should effectively be the same as before, but I didn't test there.