### PR TITLE
List all licenses in mixfile

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule BcryptElixir.Mixfile do
     [
       files: ["lib", "c_src", "mix.exs", "Makefile*", "README.md", "LICENSE"],
       maintainers: ["David Whitlock"],
-      licenses: ["BSD"],
+      licenses: ["BSD-3-Clause", "ISC", "BSD-4-Clause"],
       links: %{
         "Changelog" => "#{@source_url}/blob/master/CHANGELOG.md",
         "GitHub" => @source_url


### PR DESCRIPTION
Hex.pm recommends that the list of package licenses in the mixfile be SPDX identifiers. I think I've got the right licenses picked out.