### PR TITLE
Fix compilation warnings on Elixir 1.17

### DIFF
--- a/lib/bcrypt/base.ex
+++ b/lib/bcrypt/base.ex
@@ -67,7 +67,7 @@ defmodule Bcrypt.Base do
   def checkpass_nif(_, _), do: :erlang.nif_error(:not_loaded)
 
   defp load_nif do
-    path = :filename.join(:code.priv_dir(:bcrypt_elixir), 'bcrypt_nif')
+    path = :filename.join(:code.priv_dir(:bcrypt_elixir), ~c'bcrypt_nif')
     :erlang.load_nif(path, 0)
   end
 

--- a/lib/bcrypt/base.ex
+++ b/lib/bcrypt/base.ex
@@ -67,7 +67,7 @@ defmodule Bcrypt.Base do
   def checkpass_nif(_, _), do: :erlang.nif_error(:not_loaded)
 
   defp load_nif do
-    path = :filename.join(:code.priv_dir(:bcrypt_elixir), ~c'bcrypt_nif')
+    path = :filename.join(:code.priv_dir(:bcrypt_elixir), "bcrypt_nif")
     :erlang.load_nif(path, 0)
   end
 


### PR DESCRIPTION
Fixes the following compilation warnings with Elixir 1.17.

```
warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
```